### PR TITLE
Fix: Back sentence newline

### DIFF
--- a/src/ContentScript/index.ts
+++ b/src/ContentScript/index.ts
@@ -31,10 +31,9 @@ async function handleAddAnkiCardButtonClick(sentenceDiv: Element): Promise<void>
 }
 
 function extractSentenceFromCard(cardDiv: Element): Sentence {
-    const front = (cardDiv.querySelector(".card-front") as HTMLElement).innerText;
-    const back = (cardDiv.querySelector(".card-back") as HTMLElement).innerText;
+    const front = (cardDiv.querySelector(".card-front") as HTMLElement).innerHTML;
+    const back = (cardDiv.querySelector(".card-back") as HTMLElement).innerHTML;
     return { front, back };
-
 }
 
 export {};


### PR DESCRIPTION
Anki apparently expects newlines to be literally `<br>` instead of `\n` in the sentence card, so this fix changes the logic that extracts the sentences so it uses the element `innerHTML` instead of `innerText`.